### PR TITLE
Fix invalid json example

### DIFF
--- a/doc/api/writing-handlers-in-json.md
+++ b/doc/api/writing-handlers-in-json.md
@@ -29,7 +29,7 @@ If the adventure game wanted to indicate to SteelSeries Engine that you will be 
     {
       "game": "ADVENTURE",
       "event": "HEALTH",
-      "min_value": 0
+      "min_value": 0,
       "max_value": 100,
       "icon_id": 1
     }


### PR DESCRIPTION
Fixes missing , in json example in doc/api/writing-handlers-in-json.md