### PR TITLE
Update JSON example regarding data accessors

### DIFF
--- a/doc/api/json-handlers-screen.md
+++ b/doc/api/json-handlers-screen.md
@@ -219,11 +219,12 @@ For example, assume the following event payload structure:
 {
   "game": "MYGAME",
   "event": "MYEVENT",
-  "value": 56,
-  "frame": 
-  {
-    "textvalue": "this is some text",
-    "numericalvalue": 88
+  "datas": {
+    "value": 56,
+    "frame": {
+      "textvalue": "this is some text",
+      "numericalvalue": 88
+    }
   }
 }
 ```


### PR DESCRIPTION
According to documentation [here](https://github.com/SteelSeries/gamesense-sdk/blob/master/doc/api/sending-game-events.md#event-context-data) the `frame` and `value` keys should be nested under a `datas` key.